### PR TITLE
Pamsupdates

### DIFF
--- a/docs/src/pages/use-cases/cold-chain/index.mdx
+++ b/docs/src/pages/use-cases/cold-chain/index.mdx
@@ -3,7 +3,7 @@ title: Cold-chain monitoring
 description: Cold-chain monitoring
 ---
 
-- UPDATED 02/28/2021 
+- UPDATED 02/28/2021
 
 The vaccine lots need to be kept at a constant temperature for a period of time. The sensor telemetry data coming from the refrigerated shipping containers is processed to assess cold-chain violations.
 
@@ -33,9 +33,9 @@ The solution for this use case includes streaming telemetry events, a stateful m
 1. Create the following artifacts in the `eventstreams` namespace on your OpenShift cluster (_NOTE: If you happened to have an existing IBM Event Streams instance on a different namespace already, you don't need to create an new one but make sure you use the appropriate namespace name throughout the rest of the tutorial_). We will refer to this namespace as `YOUR_EVENT_STREAMS_NAMESPACE` throughout this tutorial:
 
    1. Create an EventStreams instance _(via the [Event Streams Custom Resource](https://ibm.github.io/event-streams/installing/installing/#install-an-event-streams-instance))_.
-   1. Create a [Kafka User with SCRAM-based credentials](https://ibm.github.io/event-streams/security/managing-access/#managing-access-to-kafka-resources), as required by the [Vaccine Reefer Simulator](https://github.com/ibm-cloud-architecture/vaccine-reefer-simulator#application-deployment).
-   1. Create a [Kafka User with TLS-based credentials](https://ibm.github.io/event-streams/security/managing-access/#managing-access-to-kafka-resources), as required by the [Vaccine Monitoring Agent](https://github.com/ibm-cloud-architecture/vaccine-monitoring-agent#create-a-tls-user).
-   1. Create two [Kafka Topics](https://ibm.github.io/event-streams/getting-started/creating-topics/). One for the container telemetries events and another for the vaccine cold-chain violation alert events. These topics will be refered as `YOUR_TELEMETRIES_TOPIC` and `YOUR_REEFER_TOPIC` respectively throughout this tutorial. For the instructions on this tutorial, we will assume the names for these two topics to be `reefers.telemetries` and `vaccine.reefers` respectively.
+   1. Create a Kafka User `scram-user` with [SCRAM-based credentials](https://ibm.github.io/event-streams/security/managing-access/#managing-access-to-kafka-resources), as required by the [Vaccine Reefer Simulator](https://github.com/ibm-cloud-architecture/vaccine-reefer-simulator#application-deployment).
+   1. Create a Kafka User `tls-user` with [TLS-based credentials](https://ibm.github.io/event-streams/security/managing-access/#managing-access-to-kafka-resources), as required by the [Vaccine Monitoring Agent](https://github.com/ibm-cloud-architecture/vaccine-monitoring-agent#create-a-tls-user).
+   1. Create two [Kafka Topics](https://ibm.github.io/event-streams/getting-started/creating-topics/). One for the container telemetries events and another for the vaccine cold-chain violation alert events. These topics will be refered as `YOUR_TELEMETRIES_TOPIC` and `YOUR_REEFER_TOPIC` respectively throughout this tutorial. For the instructions on this tutorial, we will assume the names for these two topics to be `reefer.telemetries` and `vaccine.reefers` respectively.
 
 1. Create a new project that will be used for the deployment of all other components. This will be refered as `YOUR_PROJECT_NAME` throughout the rest of this tutorial. For the instructions on this tutorial, We will assume the name for the project is `vaccine-solution`.
 1. [OpenShift CLI](https://cloud.ibm.com/docs/openshift?topic=openshift-openshift-cli) on your local environment.
@@ -107,7 +107,7 @@ To get more details of this Python Flask application [read this note](/solution/
 
   ```shell
   oc create configmap reefer-simul-cm \
-  --from-literal=KAFKA_MAIN_TOPIC=<YOUR_TELEMETRY_TOPIC> 
+  --from-literal=KAFKA_MAIN_TOPIC=<YOUR_TELEMETRY_TOPIC>
   ```
 
   where
@@ -148,9 +148,9 @@ To get more details of this Python Flask application [read this note](/solution/
 1. Compile, build the docker image and push to the registry
 
   ```shell
-  # In the vaccine simulator project 
+  # In the vaccine simulator project
   docker build -t ibmcase/vaccine-reefer-simulator  .
-  docker push ibmcase/vaccine-reefer-simulator 
+  docker push ibmcase/vaccine-reefer-simulator
   ```
 
 1. Deploy Vaccine Reefer Simulator microservice components (application plus a service and a route to make it accessible) via the following `oc apply` command:

--- a/docs/src/pages/use-cases/cold-chain/index.mdx
+++ b/docs/src/pages/use-cases/cold-chain/index.mdx
@@ -3,7 +3,7 @@ title: Cold-chain monitoring
 description: Cold-chain monitoring
 ---
 
-- UPDATED 02/28/2021
+- UPDATED 03/05/2021
 
 The vaccine lots need to be kept at a constant temperature for a period of time. The sensor telemetry data coming from the refrigerated shipping containers is processed to assess cold-chain violations.
 


### PR DESCRIPTION
* Added the names of the KAFKA users `scram-user` and `tls-user`
* Updated the name of the topic from `reefers.telemetries` to `reefer.telemetries`
Otherwise you get this error:
```
19:52:12 INFO  [io.quarkus] (main) Installed features: [cdi, kafka-streams, kubernetes, kubernetes-client, mutiny, rest-client, resteasy, resteasy-jsonb, smallrye-context-propagation, smallrye-health, smallrye-metrics, smallrye-openapi, smallrye-reactive-messaging, smallrye-reactive-messaging-kafka, swagger-ui, vertx]
19:52:14 INFO  [io.sm.health] (vert.x-worker-thread-0) SRHCK01001: Reporting health down status: {"status":"DOWN","checks":[{"name":"Kafka Streams topics health check","status":"DOWN","data":{"missing_topics":"reefer.telemetries"}}]}
```




